### PR TITLE
Update CVE-2024-27198.json

### DIFF
--- a/exploits/github/2024/CVE-2024-27198.json
+++ b/exploits/github/2024/CVE-2024-27198.json
@@ -278,33 +278,5 @@
         "watchers": 0,
         "score": 0,
         "subscribers_count": 0
-    },
-    {
-        "cve": "CVE-2024-27198",
-        "poc_github": true,
-        "full_name": "Pypi-Project/RCity-CVE-2024-27198",
-        "owner_login": "Pypi-Project",
-        "owner_id": 177478126,
-        "owner_html_url": "https://github.com/Pypi-Project",
-        "owner_avatar_url": "https://avatars.githubusercontent.com/u/177478126?v=4",
-        "html_url": "https://github.com/Pypi-Project/RCity-CVE-2024-27198",
-        "description": "CVE-2024-27198 & CVE-2024-27199 PoC - RCE, Admin Account Creation, Enum Users, Server Information  #RCE #python3",
-        "fork": false,
-        "created_at": "2024-08-12T04:46:34Z",
-        "updated_at": "2024-08-13T09:27:51Z",
-        "pushed_at": "2024-08-12T04:47:04Z",
-        "stargazers_count": 5,
-        "watchers_count": 5,
-        "has_discussions": false,
-        "forks_count": 3,
-        "allow_forking": true,
-        "is_template": false,
-        "web_commit_signoff_required": false,
-        "topics": "[]",
-        "visibility": "public",
-        "forks": 3,
-        "watchers": 5,
-        "score": 0,
-        "subscribers_count": 1
     }
 ]


### PR DESCRIPTION
One malicious Poc project: https://github.com/Pypi-Project/RCity-CVE-2024-27198 was removed
Analysis and screenshots from my post: https://x.com/AabyssZG/status/1823247212119519517